### PR TITLE
Fix memory leak: ADD free func for mlx

### DIFF
--- a/main.c
+++ b/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rnakai <rnakai@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kkamashi <kkamashi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/10/25 15:17:06 by kkamashi          #+#    #+#             */
-/*   Updated: 2020/11/21 13:51:08 by rnakai           ###   ########.fr       */
+/*   Updated: 2020/11/22 13:17:33 by kkamashi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,6 +39,8 @@ int main(int argc, char **argv)
 	if (game.should_game_start == ERROR)
 	{
 		print_error_msg(&game.err_msg);
+		free(game.mlx);
+		game.mlx = NULL;
 		return (ERROR);
 	}
 	// TRANSFORM MAP INTO RECTANGLE


### PR DESCRIPTION
## issueで挙がっていたメモリリーク箇所の修正

以下のissue
https://github.com/Kotaro666-dev/team_cub3D/issues/41

### 原因

不正なcubファイルが読み込まれた際に、main関数冒頭でmlx_initしていたmlxがfreeされていなかったため。

### 解決方法

cubファイルに不正が見つかった場合のエラー処理をする条件分岐内で、mlxをfreeする。

```
game.should_game_start = handle_command_line(argc, argv, &game);
	if (game.should_game_start == ERROR)
	{
		print_error_msg(&game.err_msg);
		free(game.mlx);
		game.mlx = NULL;
		return (ERROR);
	}
```

### 気になること

気になる点は、nfukadaさんが以下のように話していたこと。

>mlxは構造体になっていてfreeでは解放しきれなかったと思います（valgrindでstill reachableを確認すると分かると思います）。minilibx-linuxではmlx_destroy_display関数が実装されて解放できるようになったみたいです。ただ最近実装されたばかりで関数名typoしてたりしてます。
https://discord.com/channels/761086132959838258/762257480331558942/772422539203837963

