### PR TITLE
Finish fixing: now that it generates accurate bmp file with odd width

### DIFF
--- a/includes/bmp.h
+++ b/includes/bmp.h
@@ -6,7 +6,7 @@
 /*   By: kkamashi <kkamashi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/10/28 15:52:41 by kkamashi          #+#    #+#             */
-/*   Updated: 2020/11/22 19:42:41 by kkamashi         ###   ########.fr       */
+/*   Updated: 2020/11/23 18:44:57 by kkamashi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,7 @@
 # define OFFSET_TO_DATA HEADERSIZE
 # define PLANES 1
 # define COLOR 24
+# define BYTES_PER_PIXEL 3
 
 int		create_bmp(t_game *game);
 void	render_bmp_image(t_game *game);

--- a/includes/structs/struct_bmp.h
+++ b/includes/structs/struct_bmp.h
@@ -6,7 +6,7 @@
 /*   By: kkamashi <kkamashi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/11/22 19:26:22 by kkamashi          #+#    #+#             */
-/*   Updated: 2020/11/22 19:46:38 by kkamashi         ###   ########.fr       */
+/*   Updated: 2020/11/23 18:44:15 by kkamashi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,6 +27,7 @@ typedef struct		s_bmp
 	int				padding_size;
 	unsigned char	padding[3];
 	int				color;
+	int				width_in_bytes;
 }					t_bmp;
 
 #endif

--- a/srcs/bmp/bmp.c
+++ b/srcs/bmp/bmp.c
@@ -6,7 +6,7 @@
 /*   By: kkamashi <kkamashi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/10/28 15:50:51 by kkamashi          #+#    #+#             */
-/*   Updated: 2020/11/23 13:44:41 by kkamashi         ###   ########.fr       */
+/*   Updated: 2020/11/23 18:44:46 by kkamashi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,8 @@ static void		init_bmp(t_bmp *bmp, t_game *game)
 	bmp->height = game->cub_data.rez.height;
 	bmp->image_size = bmp->width * bmp->height * 3;
 	bmp->file_size = TOTALHEADERSIZE + bmp->image_size;
-	bmp->padding_size = (4 - (bmp->width) % 4) % 4;
+	bmp->width_in_bytes = bmp->width * BYTES_PER_PIXEL;
+	bmp->padding_size = (4 - (bmp->width_in_bytes) % 4) % 4;
 	ft_bzero(bmp->file_header, FILEHEADERSIZE);
 	ft_bzero(bmp->info_header, INFOHEADERSIZE);
 	ft_bzero(bmp->padding, 3);


### PR DESCRIPTION
## 奇数値のwidthにも対応

画像の書き出しには、以下のstackover flowのコードを参考にしていました。
https://stackoverflow.com/questions/2654480/writing-bmp-image-in-pure-c-c-without-other-libraries/

こちらを読み返していると、自分のコードに抜けていた箇所があり、追記したところ問題なく生成するようになりました。

## 試した値

width: 501, 503, 509

rnakaiさんの環境でも試してもらえると助かります。