### PR TITLE
move_playerを修正し、壁の中に入らないようにした

### DIFF
--- a/srcs/game/hook/print_debug_info.c
+++ b/srcs/game/hook/print_debug_info.c
@@ -6,7 +6,7 @@
 /*   By: rnakai <rnakai@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/11/25 10:26:13 by rnakai            #+#    #+#             */
-/*   Updated: 2020/11/29 11:04:19 by rnakai           ###   ########.fr       */
+/*   Updated: 2020/11/29 13:05:21 by rnakai           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,18 +23,16 @@
 
 void		print_debug_info_in_game(t_game *game)
 {
-	draw_player_rect(game,
-		init_rect_info(g_debug.left_edge_px, g_info.height / 2, 30, 30),
-		SKY_BLUE);
-	draw_player_rect(game,
-		init_rect_info(g_debug.right_edge_px, g_info.height / 2, 30, 30),
-		BROWN);
-	mlx_put_image_to_window(game->mlx, game->win, game->image.img, 0, 0);
+	// draw_player_rect(game,
+	// 	init_rect_info(g_debug.left_edge_px, g_info.height / 2, 30, 30),
+	// 	SKY_BLUE);
+	// draw_player_rect(game,
+	// 	init_rect_info(g_debug.right_edge_px, g_info.height / 2, 30, 30),
+	// 	BROWN);
+	// mlx_put_image_to_window(game->mlx, game->win, game->image.img, 0, 0);
 
-	printf("left_pos:%f\n", g_debug.left_pos - TILE_SIZE / 2);
-	printf("left_edge_px:%d\n", g_debug.left_edge_px);
+	(void)game;
+	printf("player x:%f\n", g_player.x);
+	printf("player y:%f\n", g_player.y);
 	printf("\n");
-	printf("right_pos:%f\n", g_debug.right_pos + TILE_SIZE / 2);
-	printf("right_edge_px:%d\n", g_debug.right_edge_px);
-	printf("----------------------\n");
 }

--- a/srcs/game/system/move_player.c
+++ b/srcs/game/system/move_player.c
@@ -6,7 +6,7 @@
 /*   By: rnakai <rnakai@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/11/12 12:40:01 by rnakai            #+#    #+#             */
-/*   Updated: 2020/11/27 15:26:39 by rnakai           ###   ########.fr       */
+/*   Updated: 2020/11/29 13:08:33 by rnakai           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,13 +18,23 @@ void	move_player(void)
 	float		move_step;
 	float		new_player_x;
 	float		new_player_y;
+	float		collision_check_x;
+	float		collision_check_y;
 
 	g_player.rotation_angle += g_player.turn_direction * g_player.turn_speed;
 	move_step = g_player.walk_direction * g_player.walk_speed;
-	new_player_x = g_player.x + move_step * cos(g_player.rotation_angle + g_player.side_angle);
-	new_player_y = g_player.y + move_step * sin(g_player.rotation_angle + g_player.side_angle);
-	if (!has_wall_at(new_player_x, new_player_y) &&
-		!has_sprite_at(new_player_x, new_player_y))
+	new_player_x = g_player.x +
+		move_step * cos(g_player.rotation_angle + g_player.side_angle);
+	new_player_y = g_player.y +
+		move_step * sin(g_player.rotation_angle + g_player.side_angle);
+	collision_check_x = new_player_x;
+	collision_check_y = new_player_y;
+	if ((int)collision_check_x % TILE_SIZE == 0)
+		collision_check_x--;
+	if ((int)collision_check_y % TILE_SIZE == 0)
+		collision_check_y--;
+	if (!has_wall_at(collision_check_x, collision_check_y) &&
+		!has_sprite_at(collision_check_x, collision_check_y))
 	{
 		g_player.x = new_player_x;
 		g_player.y = new_player_y;


### PR DESCRIPTION
座標が64の倍数の時、mapのidxと座標のidxにずれが生じるのが原因だったので、
媒介となるチェック用変数を挟むことで解決しました。