### PR TITLE
Add a feature: free mlx_ptr and assign null ptr to it

### DIFF
--- a/srcs/game/system/store_textures.c
+++ b/srcs/game/system/store_textures.c
@@ -6,7 +6,7 @@
 /*   By: kkamashi <kkamashi@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/11/20 16:28:48 by rnakai            #+#    #+#             */
-/*   Updated: 2020/11/25 16:31:59 by kkamashi         ###   ########.fr       */
+/*   Updated: 2020/11/29 13:25:22 by kkamashi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,6 +57,8 @@ static void	check_loaded_textures(t_game *game)
 	{
 		if (g_textures[i].img_ptr == NULL)
 		{
+			free(game->mlx);
+			game->mlx = NULL;
 			game->err_msg.which_msg = TEXTURE_FILE_NOT_VALID;
 			print_error_msg(&game->err_msg);
 			exit(1);


### PR DESCRIPTION
## 問題

以下のissue修正
https://github.com/Kotaro666-dev/team_cub3D/issues/49

## 問題

exit(1)でプログラムを終了する前に、動的確保していたmlx_ptrをfreeしていなくてもメモリリークは検出されていないかった。
おそらく、プログラム終了時にOS側が使用していたヒープ領域のメモリを自動的に解放しているからか？

## 修正方法

ただし、OS側による自動メモリ解放はOS依存である。
Cポインタの書籍によれば、製作者側でプログラムが終了する前にヒープ領域に確保したメモリは自分ですべてfreeするべきと書かれている。
なので、しっかりとこちらでfreeする形を採用した。

## 不明点

mlxポインタの中身は構造体となっており、mlx_init時に構造体メンバーのdisplayも確保されている。
そのため、例に乗っ取り自作関数free_mlx_ptr()でfreeしようとすると、game->mlx.displayのメモリ参照が不正と怒られる。
確保されているはずのgame->mlx.displayのメモリが存在していないかのよう。

## 結果

以下のコードだけ追記した
```
free(game->mlx);
game->mlx = NULL;
```