### PR TITLE
斜め壁すり抜けしないよう、new_player_x, yまでの間の座標をすべて逐一調べる実装にした。

### DIFF
--- a/srcs/game/system/move_player.c
+++ b/srcs/game/system/move_player.c
@@ -6,27 +6,52 @@
 /*   By: rnakai <rnakai@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/11/12 12:40:01 by rnakai            #+#    #+#             */
-/*   Updated: 2020/12/03 12:09:58 by rnakai           ###   ########.fr       */
+/*   Updated: 2020/12/09 11:39:50 by rnakai           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "game.h"
 #include <math.h>
+#include <stdlib.h>
 
-static int	is_there_collision(float new_player_x, float new_player_y)
+static int	is_there_collision(float to_check_x, float to_check_y)
 {
-	if (has_object_at(new_player_x, new_player_y))
+	if (has_object_at(to_check_x, to_check_y))
 		return (TRUE);
-	if ((int)new_player_x % TILE_SIZE == 0)
-		new_player_x--;
-	if ((int)new_player_y % TILE_SIZE == 0)
-		new_player_y--;
-	if (has_object_at(new_player_x, new_player_y))
+	if ((int)to_check_x % TILE_SIZE == 0)
+		to_check_x--;
+	if ((int)to_check_y % TILE_SIZE == 0)
+		to_check_y--;
+	if (has_object_at(to_check_x, to_check_y))
 		return (TRUE);
 	else
 	{
 		return (FALSE);
 	}
+}
+
+static int	is_there_wall_collision_inside_(float move_step)
+{
+	int		i;
+	float	to_check_x;
+	float	to_check_y;
+	int		minus_flag;
+
+	minus_flag = 1;
+	if (move_step < 0)
+		minus_flag = -1;
+	i = 1;
+	while (i <= abs(move_step))
+	{
+		to_check_x = g_player.x + minus_flag *
+			i * cos(g_player.rotation_angle + g_player.side_angle);
+		to_check_y = g_player.y + minus_flag *
+			i * sin(g_player.rotation_angle + g_player.side_angle);
+		if (is_there_collision(to_check_x, to_check_y))
+			return (TRUE);
+		i++;
+	}
+	return (FALSE);
 }
 
 void		move_player(void)
@@ -41,7 +66,7 @@ void		move_player(void)
 		move_step * cos(g_player.rotation_angle + g_player.side_angle);
 	new_player_y = g_player.y +
 		move_step * sin(g_player.rotation_angle + g_player.side_angle);
-	if (!is_there_collision(new_player_x, new_player_y))
+	if (!is_there_wall_collision_inside_(move_step))
 	{
 		g_player.x = new_player_x;
 		g_player.y = new_player_y;


### PR DESCRIPTION
今までは、移動先の座標1点が壁じゃなければ移動できる実装だったので、壁を通って来たとしても移動できてしまいました。

0000
0010
01P0
0000
上記のようなマップでも、斜め左上には移動できてしまいました。

なので、移動先までの間すべての座標を調べ、オブジェクトがあったら移動できないようにする実装にしました。

move_stepは、後ろ向き移動のときマイナスの値を取るので、その場合でも対応できるよう、絶対値を処理に入れています。